### PR TITLE
Fix "fe_sendauth no password supplied" exception

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,6 @@ ActiveRecord::Base.establish_connection(
   adapter:  "postgresql",
   database: "upcase_exercise",
   encoding: "utf8",
-  host: "localhost",
   min_messages: "warning"
 )
 


### PR DESCRIPTION
`fe_sendauth: no password supplied (PG::ConnectionBad)` was rised on bin/setup and bin/rake
preventing the exercise on Ubuntu 16.04, PostgreSQL 9.5

Solution inspired by this answer https://stackoverflow.com/a/36987035/653940